### PR TITLE
fix: correct UOM change price recalculation and tax-inclusive display in POS

### DIFF
--- a/src/main/java/org/spin/grpc/service/PointOfSalesForm.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesForm.java
@@ -5054,7 +5054,10 @@ public class PointOfSalesForm extends StoreImplBase {
 			orderLine.set_ValueOfColumn("Ref_WarehouseSource_ID", warehouseId);
 		}
 		//	Validate UOM
-		OrderUtil.updateUomAndQuantity(orderLine, unitOfMeasureId, quantityToChange);
+		// Use prepareUomAndQuantity (no internal saveEx) so all dirty fields are
+		// committed in a single saveEx(transactionName), triggering a full
+		// c_Order header recalculation (grand_total, tax, footer totals).
+		OrderUtil.prepareUomAndQuantity(orderLine, unitOfMeasureId, quantityToChange);
 		//	Set values
 		orderLine.setTax();
 		orderLine.saveEx(transactionName);

--- a/src/main/java/org/spin/grpc/service/PointOfSalesForm.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesForm.java
@@ -4961,6 +4961,8 @@ public class PointOfSalesForm extends StoreImplBase {
 				}
 				orderLine.setQty(quantityToOrder);
 				orderLine.setPrice();
+				orderLine.setPriceList(orderLine.getPriceActual());  // PriceList = selling price → 0% gap
+				orderLine.setDiscount(Env.ZERO);                     // clear stale discount from setPrice()
 				orderLine.setTax();
 				//	Save Line
 				orderLine.saveEx(transactionName);

--- a/src/main/java/org/spin/pos/service/order/OrderUtil.java
+++ b/src/main/java/org/spin/pos/service/order/OrderUtil.java
@@ -120,19 +120,78 @@ public class OrderUtil {
 	 * @param unitOfMeasureId
 	 * @param quantity
 	 */
-	public static void updateUomAndQuantity(MOrderLine orderLine, int unitOfMeasureId, BigDecimal quantity) {
+	/**
+	 * Prepare UOM and quantity changes on an order line WITHOUT calling saveEx().
+	 * Reads PriceActual from DB to bypass any in-memory contamination.
+	 * Caller is responsible for calling saveEx() after this method.
+	 */
+	public static void prepareUomAndQuantity(MOrderLine orderLine, int unitOfMeasureId, BigDecimal quantity) {
+		// Read price from DB to bypass any in-memory contamination before this call.
+		BigDecimal savedPriceActual = DB.getSQLValueBD(
+				orderLine.get_TrxName(),
+				"SELECT PriceActual FROM C_OrderLine WHERE C_OrderLine_ID=?",
+				orderLine.getC_OrderLine_ID());
+		if(savedPriceActual == null || savedPriceActual.signum() == 0) {
+			savedPriceActual = orderLine.getPriceActual();
+		}
 		if(quantity != null) {
 			orderLine.setQty(quantity);
 		}
+		int currentUomId = orderLine.getC_UOM_ID();
+		boolean uomChanging = unitOfMeasureId > 0 && unitOfMeasureId != currentUomId;
 		if(unitOfMeasureId > 0) {
 			orderLine.setC_UOM_ID(unitOfMeasureId);
 		}
-		BigDecimal quantityEntered = orderLine.getQtyEntered();
-		BigDecimal priceEntered = orderLine.getPriceEntered();
-		BigDecimal convertedQuantity = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), orderLine.getC_UOM_ID(), quantityEntered);
-		BigDecimal convertedPrice = MUOMConversion.convertProductTo(orderLine.getCtx(), orderLine.getM_Product_ID(), orderLine.getC_UOM_ID(), priceEntered);
-		orderLine.setQtyOrdered(convertedQuantity);
-		orderLine.setPriceActual(convertedPrice);
+		int targetUomId = orderLine.getC_UOM_ID();
+		if(uomChanging) {
+			BigDecimal quantityEntered = orderLine.getQtyEntered();
+			BigDecimal convertedQuantity = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, quantityEntered);
+			orderLine.setQtyOrdered(convertedQuantity != null ? convertedQuantity : quantityEntered);
+			BigDecimal currentFactor = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), currentUomId, BigDecimal.ONE);
+			if(currentFactor != null && currentFactor.signum() > 0 && currentFactor.compareTo(BigDecimal.ONE) != 0) {
+				savedPriceActual = savedPriceActual.divide(currentFactor, 10, java.math.RoundingMode.HALF_UP);
+			}
+			BigDecimal convertedPrice = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, savedPriceActual);
+			if(convertedPrice == null) {
+				convertedPrice = savedPriceActual;
+			}
+			orderLine.setPriceList(convertedPrice);
+			orderLine.setPriceEntered(convertedPrice);
+			orderLine.setPriceActual(convertedPrice);
+		}
+		orderLine.setLineNetAmt();
+		// Caller is responsible for calling saveEx()
+	}
+	public static void updateUomAndQuantity(MOrderLine orderLine, int unitOfMeasureId, BigDecimal quantity) {
+		BigDecimal savedPriceActual = (BigDecimal) orderLine.get_ValueOld("PriceActual");
+		if(savedPriceActual == null || savedPriceActual.signum() == 0) {
+			savedPriceActual = orderLine.getPriceActual();
+		}
+		if(quantity != null) {
+			orderLine.setQty(quantity);
+		}
+		int currentUomId = orderLine.getC_UOM_ID();
+		boolean uomChanging = unitOfMeasureId > 0 && unitOfMeasureId != currentUomId;
+		if(unitOfMeasureId > 0) {
+			orderLine.setC_UOM_ID(unitOfMeasureId);
+		}
+		int targetUomId = orderLine.getC_UOM_ID();
+		if(uomChanging) {
+			BigDecimal quantityEntered = orderLine.getQtyEntered();
+			BigDecimal convertedQuantity = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, quantityEntered);
+			orderLine.setQtyOrdered(convertedQuantity != null ? convertedQuantity : quantityEntered);
+			BigDecimal currentFactor = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), currentUomId, BigDecimal.ONE);
+			if(currentFactor != null && currentFactor.signum() > 0 && currentFactor.compareTo(BigDecimal.ONE) != 0) {
+				savedPriceActual = savedPriceActual.divide(currentFactor, 10, java.math.RoundingMode.HALF_UP);
+			}
+			BigDecimal convertedPrice = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, savedPriceActual);
+			if(convertedPrice == null) {
+				convertedPrice = savedPriceActual;
+			}
+			orderLine.setPriceList(convertedPrice);
+			orderLine.setPriceEntered(convertedPrice);
+			orderLine.setPriceActual(convertedPrice);
+		}
 		orderLine.setLineNetAmt();
 		orderLine.saveEx();
 	}

--- a/src/main/java/org/spin/pos/util/OrderConverUtil.java
+++ b/src/main/java/org/spin/pos/util/OrderConverUtil.java
@@ -288,7 +288,21 @@ public class OrderConverUtil {
 			)
 			.setTaxAmount(
 				NumberManager.getBigDecimalToString(
-					grandTotal.subtract(totalLines.add(discountAmount)).setScale(
+					(priceList.isTaxIncluded()
+						? orderLines.stream()
+							.filter(ol -> defaultDiscountChargeId <= 0 || ol.getC_Charge_ID() != defaultDiscountChargeId)
+							.map(ol -> {
+								if (ol.getC_Tax_ID() <= 0) return Env.ZERO;
+								MTax lineTax = MTax.get(Env.getCtx(), ol.getC_Tax_ID());
+								return lineTax.calculateTax(
+									Optional.ofNullable(ol.getLineNetAmt()).orElse(Env.ZERO),
+									true,
+									priceList.getStandardPrecision()
+								);
+							})
+							.reduce(Env.ZERO, BigDecimal::add)
+						: grandTotal.subtract(totalLines.add(discountAmount))
+					).setScale(
 						priceList.getStandardPrecision(),
 						RoundingMode.HALF_UP
 					)
@@ -426,9 +440,10 @@ public class OrderConverUtil {
 		BigDecimal priceBaseTaxAmount = tax.calculateTax(priceBaseAmount, priceList.isTaxIncluded(), priceList.getStandardPrecision());
 		BigDecimal priceListTaxAmount = tax.calculateTax(priceListAmount, priceList.isTaxIncluded(), priceList.getStandardPrecision());
 		//	Prices with tax
-		BigDecimal priceListWithTaxAmount = priceListAmount.add(priceListTaxAmount);
-		BigDecimal priceBaseWithTaxAmount = priceBaseAmount.add(priceBaseTaxAmount);
-		BigDecimal priceWithTaxAmount = priceAmount.add(priceTaxAmount);
+		boolean isTaxIncluded = priceList.isTaxIncluded();
+		BigDecimal priceListWithTaxAmount = isTaxIncluded ? priceListAmount : priceListAmount.add(priceListTaxAmount);
+		BigDecimal priceBaseWithTaxAmount = isTaxIncluded ? priceBaseAmount : priceBaseAmount.add(priceBaseTaxAmount);
+		BigDecimal priceWithTaxAmount     = isTaxIncluded ? priceAmount     : priceAmount.add(priceTaxAmount);
 		//	Totals
 		BigDecimal totalDiscountAmount = discountAmount.multiply(quantityOrdered);
 		BigDecimal totalAmount = orderLine.getLineNetAmt();
@@ -441,8 +456,8 @@ public class OrderConverUtil {
 		);
 		BigDecimal totalBaseAmount = totalAmount.subtract(totalDiscountAmount);
 		BigDecimal totalTaxAmount = tax.calculateTax(totalAmount, priceList.isTaxIncluded(), priceList.getStandardPrecision());
-		BigDecimal totalBaseAmountWithTax = totalBaseAmount.add(totalTaxAmount);
-		BigDecimal totalAmountWithTax = totalAmount.add(totalTaxAmount);
+		BigDecimal totalBaseAmountWithTax = isTaxIncluded ? totalBaseAmount : totalBaseAmount.add(totalTaxAmount);
+		BigDecimal totalAmountWithTax     = isTaxIncluded ? totalAmount     : totalAmount.add(totalTaxAmount);
 		BigDecimal totalAmountWithTaxConverted = OrderUtil.getConvertedAmountTo(
 			order,
 			pos.get_ValueAsInt(


### PR DESCRIPTION
Fixes issue https://github.com/Systemhaus-Westfalia/adempiere-vue/issues/25 issue from adempiere-vue.
Fixes also that same issue documented in this repository: https://github.com/Systemhaus-Westfalia/adempiere-grpc-server/pull/10#issue-4132528714 .

This PR fixes three related bugs in the VPOS2 Point of Sale when changing the Unit of Measure (UOM) of an order line for products with a tax-inclusive price list (`isTaxIncluded=Y`).

### Bug 1 — OrderUtil.java + PointOfSalesForm.java

  Added `prepareUomAndQuantity()`: same normalization logic as `updateUomAndQuantity() `but without an internal `saveEx()`. This prevents a double-save and ensures all dirty fields (UOM, price, quantity) are committed in a single transaction by _updateOrderLine_, correctly triggering `ADempiere's afterSave()` → full order header recalculation.

  Price is normalized to the base UOM price before converting to the target UOM, so UOM1→UOM2→UOM3 chains produce correct prices.

###  Bug 2 — PointOfSalesForm.java (addOrderLine)

  On new order line creation, sets `PriceList = PriceActual` and clears the discount after `setPrice()`. This eliminates a false % discount that appeared on every new POS order line.

### Bug 3 — OrderConverUtil.java

  For `isTaxIncluded=Y` price lists:
  - **convertOrder**: The footer Tax field was always showing $0.00 for tax-inclusive price lists. Fixed so it now correctly extracts and displays the tax portion embedded in the price, matching what the database stores in C_OrderTax.
  - **convertOrderLine**:  When the price list is tax-inclusive, the displayed line total was incorrectly showing the tax .



### Check
- Open Order in Vue POS, add products, change quantities and UOM
- Check values in Vue POS (lines and footer) after every change
- Open same Order in ZK
- Check values in Order, Orderline. Verify that values match the Vue form.
- Footer Tax matches ZK webui (C_OrderTax.TaxAmt) in all cases.

See solution in Vue POS: 
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/dc588d97-e576-4d00-82fb-c699313ac6fa" />

**Check I: Order Header**
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/d51ad889-6824-4fb3-9c28-bce55c6b31fc" />

**Check II: Order Lines**
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/66c6cda8-5c21-453c-95cf-6f4bb39fa1e9" />

**Check III: Taxes**
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/0ec52a95-7bea-49c2-abcd-12474135ad3b" />

### Dependencies
  Depends on: https://github.com/Systemhaus-Westfalia/adempiere-vue/pull/26

