### PR TITLE
fix: use PriceList as Base for UOM Conversion and Reset Discount to Zero

### DIFF
--- a/src/main/java/org/spin/pos/service/order/OrderUtil.java
+++ b/src/main/java/org/spin/pos/service/order/OrderUtil.java
@@ -126,13 +126,14 @@ public class OrderUtil {
 	 * Caller is responsible for calling saveEx() after this method.
 	 */
 	public static void prepareUomAndQuantity(MOrderLine orderLine, int unitOfMeasureId, BigDecimal quantity) {
-		// Read price from DB to bypass any in-memory contamination before this call.
+		// Read PriceList (not PriceActual) to convert from the clean list price,
+		// ignoring any discount the user had set before the UOM change.
 		BigDecimal savedPriceActual = DB.getSQLValueBD(
 				orderLine.get_TrxName(),
-				"SELECT PriceActual FROM C_OrderLine WHERE C_OrderLine_ID=?",
+				"SELECT PriceList FROM C_OrderLine WHERE C_OrderLine_ID=?",
 				orderLine.getC_OrderLine_ID());
 		if(savedPriceActual == null || savedPriceActual.signum() == 0) {
-			savedPriceActual = orderLine.getPriceActual();
+			savedPriceActual = orderLine.getPriceList();
 		}
 		if(quantity != null) {
 			orderLine.setQty(quantity);
@@ -158,6 +159,7 @@ public class OrderUtil {
 			orderLine.setPriceList(convertedPrice);
 			orderLine.setPriceEntered(convertedPrice);
 			orderLine.setPriceActual(convertedPrice);
+			orderLine.setDiscount(Env.ZERO);
 		}
 		orderLine.setLineNetAmt();
 		// Caller is responsible for calling saveEx()


### PR DESCRIPTION

  Closes #11

  ## Change

  In `OrderUtil.prepareUomAndQuantity`, read `PriceList` from the database instead of `PriceActual` as the basis for UOM price conversion, and explicitly set `Discount = 0` after the conversion.

  ## Result

  | Field | Before | After |
  |-------|--------|-------|
  | Price | $0.96 (discount embedded) | $1.00 (clean list price) |
  | %Dcto | 0.00% | 0.00% |
  | Discount | 0.00 | 0.00 |

  ## Test
  New order → product 51014 → qty 3 → price $24.00 (4% discount) →  change UOM Bolsa → kg → Price shows $1.00, %Dcto = 0%, Discount = 0.00 ✓
<img width="3277" height="1823" alt="image" src="https://github.com/user-attachments/assets/8a5b3681-0614-46d6-9fb3-d0532f5ef935" />
