### PR TITLE
fix: Use MProductPricing to Look Up Base Price on UOM Change

### DIFF
--- a/src/main/java/org/spin/pos/service/order/OrderUtil.java
+++ b/src/main/java/org/spin/pos/service/order/OrderUtil.java
@@ -35,6 +35,8 @@ import org.compiere.model.MPOS;
 import org.compiere.model.MPayment;
 import org.compiere.model.MUOMConversion;
 import org.compiere.model.MPriceList;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPricing;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
 import org.compiere.model.Query;
@@ -148,13 +150,35 @@ public class OrderUtil {
 			BigDecimal quantityEntered = orderLine.getQtyEntered();
 			BigDecimal convertedQuantity = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, quantityEntered);
 			orderLine.setQtyOrdered(convertedQuantity != null ? convertedQuantity : quantityEntered);
-			BigDecimal currentFactor = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), currentUomId, BigDecimal.ONE);
-			if(currentFactor != null && currentFactor.signum() > 0 && currentFactor.compareTo(BigDecimal.ONE) != 0) {
-				savedPriceActual = savedPriceActual.divide(currentFactor, 10, java.math.RoundingMode.HALF_UP);
-			}
-			BigDecimal convertedPrice = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, savedPriceActual);
-			if(convertedPrice == null) {
-				convertedPrice = savedPriceActual;
+			// Use same methodology as CalloutOrder
+			// to avoid precision loss from reversing intermediate rounded UOM prices.
+			MOrder order = (MOrder) orderLine.getC_Order();
+			MProductPricing productPricing = new MProductPricing(
+				orderLine.getM_Product_ID(),
+				order.getC_BPartner_ID(),
+				orderLine.getQtyOrdered(),
+				order.isSOTrx(),
+				null);
+			productPricing.setM_PriceList_ID(order.getM_PriceList_ID());
+			productPricing.setPriceDate(order.getDateOrdered());
+			BigDecimal baseStdPrice = productPricing.getPriceStd();
+			BigDecimal convertedPrice;
+			if(baseStdPrice != null && baseStdPrice.signum() > 0) {
+				int productUomId = MProduct.get(orderLine.getCtx(), orderLine.getM_Product_ID()).getC_UOM_ID();
+				if(targetUomId == productUomId) {
+					convertedPrice = baseStdPrice;
+				} else {
+					convertedPrice = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, baseStdPrice);
+					if(convertedPrice == null) convertedPrice = baseStdPrice;
+				}
+			} else {
+				// Fallback: factor-based conversion
+				BigDecimal currentFactor = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), currentUomId, BigDecimal.ONE);
+				if(currentFactor != null && currentFactor.signum() > 0 && currentFactor.compareTo(BigDecimal.ONE) != 0) {
+					savedPriceActual = savedPriceActual.divide(currentFactor, 10, java.math.RoundingMode.HALF_UP);
+				}
+				convertedPrice = MUOMConversion.convertProductFrom(orderLine.getCtx(), orderLine.getM_Product_ID(), targetUomId, savedPriceActual);
+				if(convertedPrice == null) convertedPrice = savedPriceActual;
 			}
 			orderLine.setPriceList(convertedPrice);
 			orderLine.setPriceEntered(convertedPrice);


### PR DESCRIPTION
Closes #13                                                                                                                                                                              
                                                                                                                                                                                          
  ## What changed 
                                                                                                                                                                                          
  `OrderUtil.prepareUomAndQuantity` — replaced the factor-based price normalization with a direct `MProductPricing` lookup, mirroring the methodology of `CalloutOrder.amt` .                                                                          
                                                                                                                                                                                          
  Instead of:     
  1. Divide stored (already rounded) intermediate price by current UOM factor                                                                                                             
  2. Multiply result by target UOM factor                                    
  → compounds two rounding errors                                                                                                                                                         
                                                                                                                                                                                          
  Now:
  1. Fetch authoritative standard price from price list via `MProductPricing`                                                                                                             
  2. Single forward conversion to target UOM                                 
  → no reverse step, no accumulated rounding error                                                                                                                                        
                                                  
  A factor-based fallback is retained in case `MProductPricing` returns no price.                                                                                                         
                                                                                                                                                                                          
  ## Test                                                                                                                                                                                 
                                                                                                                                                                                          
  - A Product  (Sack 25Kg= $25.00, isTaxIncluded price list)
  - New POS order → change UOM: Sack 25Kg → kg → Pound (Libra) → Sack 25Kg → **$25.00** ✓                                                                                                                 
  - Pound (Libra) → kg → **$1.00** ✓                                             
  - Sack 25Kg ↔ kg (round factors, previously working) → still correct ✓                                                                                                                      
  - Set discounted price ($24) → change UOM → price resets to clean list price ✓
